### PR TITLE
Add Apple Silicon detection and dynamic Mac download links

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   moduleNameMapper: {
+    '^~/assets/.*$': '<rootDir>/test/__mocks__/fileMock.js',
+    '^@/assets/.*$': '<rootDir>/test/__mocks__/fileMock.js',
     '^@/(.*)$': '<rootDir>/$1',
     '^~/(.*)$': '<rootDir>/$1',
     '^vue$': 'vue/dist/vue.common.js'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
         </div>
         <div class="col-12 col-md-6">
           <div v-if="$device.isMacOS || $device.isIos">
-            <a href="https://github.com/gavinbenda/platinum-md/releases/download/v1.2.0/platinum-md-1.2.0.dmg" target="_blank" class="button--green download-button px-5"><font-awesome-icon :icon="['fab', 'apple']" class="button-icon" /><span>Download for MacOS</span></a>
+            <a :href="macDownloadLink" target="_blank" class="button--green download-button px-5"><font-awesome-icon :icon="['fab', 'apple']" class="button-icon" /><span>Download for MacOS</span></a>
             <b-button v-b-modal.install-macos class="mt-3">Please read the Install Instructions <font-awesome-icon :icon="['fas', 'external-link-alt']" /></b-button>
           </div>
           <div v-else-if="$device.isWindows || $device.isMobile">
@@ -28,7 +28,7 @@
           <div class="other-platforms">
             <h3>Also available for other platforms</h3>
             <div v-if="!$device.isMacOS">
-              <a href="https://github.com/gavinbenda/platinum-md/releases/download/v1.2.0/platinum-md-1.2.0.dmg" target="_blank"><font-awesome-icon :icon="['fab', 'apple']" /> Download for MacOS</a>
+              <a :href="macDownloadLink" target="_blank"><font-awesome-icon :icon="['fab', 'apple']" /> Download for MacOS</a>
             </div>
             <div v-if="!$device.isWindows">
               <a href="https://github.com/gavinbenda/platinum-md/releases/download/v1.2.0/platinum-md.Setup.1.2.0.exe" target="_blank"><font-awesome-icon :icon="['fab', 'windows']" /> Download for Windows</a>
@@ -112,6 +112,20 @@ export default {
         { hid: 'og:image', name: 'og:image', content: this.url + ogImage },
         { hid: 'og:type', name: 'og:type', content: 'website' }
       ]
+    }
+  },
+  computed: {
+    isAppleSilicon () {
+      if (process.server) return false
+      const arch = navigator.userAgentData && navigator.userAgentData.architecture
+      if (arch) {
+        return arch.toLowerCase().includes('arm')
+      }
+      return /arm|apple\s?m\d/i.test(navigator.userAgent)
+    },
+    macDownloadLink () {
+      const base = 'https://github.com/gavinbenda/platinum-md/releases/download/v1.2.1/'
+      return this.isAppleSilicon ? base + 'platinum-md-1.2.1-m1-hotfix.dmg' : base + 'platinum-md-1.2.1.dmg'
     }
   }
 }

--- a/test/Architecture.spec.js
+++ b/test/Architecture.spec.js
@@ -1,0 +1,22 @@
+import { shallowMount } from '@vue/test-utils'
+import Index from '@/pages/index.vue'
+
+describe('Mac download link', () => {
+  const originalNavigator = { ...global.navigator }
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', { value: originalNavigator, configurable: true })
+  })
+
+  test('uses m1 dmg for arm architecture', () => {
+    Object.defineProperty(global.navigator, 'userAgentData', { value: { architecture: 'arm' }, configurable: true })
+    const wrapper = shallowMount(Index, { mocks: { $device: { isMacOS: true, isIos: false, isWindows: false, isMobile: false } }, stubs: ['font-awesome-icon', 'b-button', 'b-modal'] })
+    expect(wrapper.vm.macDownloadLink).toContain('platinum-md-1.2.1-m1-hotfix.dmg')
+  })
+
+  test('uses intel dmg for non-arm architecture', () => {
+    Object.defineProperty(global.navigator, 'userAgentData', { value: { architecture: 'x86' }, configurable: true })
+    const wrapper = shallowMount(Index, { mocks: { $device: { isMacOS: true, isIos: false, isWindows: false, isMobile: false } }, stubs: ['font-awesome-icon', 'b-button', 'b-modal'] })
+    expect(wrapper.vm.macDownloadLink).toContain('platinum-md-1.2.1.dmg')
+  })
+})

--- a/test/__mocks__/fileMock.js
+++ b/test/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub'


### PR DESCRIPTION
## Summary
- detect CPU architecture on the client
- compute `macDownloadLink` based on Apple Silicon detection
- update Mac links to use the computed value
- adjust Jest config to mock asset imports
- add tests simulating arm and intel browsers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684122a47c088328bf3b2e207327a80b